### PR TITLE
feat(sdk): Add support for multi-file file-based scripts

### DIFF
--- a/src/Cake.Generator.TestApp/Program.cs
+++ b/src/Cake.Generator.TestApp/Program.cs
@@ -167,8 +167,36 @@ Task("IntegrationTest-PrepareAppCs")
             data.IntegrationTest.CakeSdkCsCode);
     });
 
-Task("IntegrationTest-PrepareProjects")
+Task("IntegrationTest-PrepareMultiFile")
     .IsDependentOn("IntegrationTest-PrepareAppCs")
+    .Does<BuildData>((ctx, data) =>
+    {
+        // Create the cake.sdk.files directory
+        CreateDirectory(data.IntegrationTest.CakeSdkFilesFolder);
+
+        // Write the main cake.sdk.files.cs file
+        System.IO.File.WriteAllText(
+            data.IntegrationTest.CakeSdkFilesCs.FullPath,
+            data.IntegrationTest.CakeSdkFilesCsCode);
+
+        // Write the Models.cs file
+        System.IO.File.WriteAllText(
+            data.IntegrationTest.CakeSdkFilesModelsCs.FullPath,
+            data.IntegrationTest.CakeSdkFilesModelsCsCode);
+
+        // Write the Utilities.cs file
+        System.IO.File.WriteAllText(
+            data.IntegrationTest.CakeSdkFilesUtilitiesCs.FullPath,
+            data.IntegrationTest.CakeSdkFilesUtilitiesCsCode);
+
+        // Write the Excluded.cs file (this should not be compiled)
+        System.IO.File.WriteAllText(
+            data.IntegrationTest.CakeSdkFilesExcludedCs.FullPath,
+            data.IntegrationTest.CakeSdkFilesExcludedCsCode);
+    });
+
+Task("IntegrationTest-PrepareProjects")
+    .IsDependentOn("IntegrationTest-PrepareMultiFile")
     .Does<BuildData>(
         Verbosity.Diagnostic,
         (ctx, data) =>

--- a/src/Cake.Sdk/Cake.Sdk.csproj
+++ b/src/Cake.Sdk/Cake.Sdk.csproj
@@ -42,9 +42,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="Cake.Generator" VersionOverride="__VERSION__" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'__IncludeAdditionalFiles__' != ''">
+    <Compile Include="__IncludeAdditionalFiles__" Exclude="__ExcludeAdditionalFiles__" />
   </ItemGroup>
 
 </Project>]]></SdkPropsContent>
@@ -56,8 +59,7 @@
           <!-- Replace placeholders with actual values and MSBuild properties -->
       <PropertyGroup>
         <DollarSign>$</DollarSign>
-        <PropertyReference>$(DollarSign)(ManagePackageVersionsCentrally)</PropertyReference>
-        <SdkPropsContentWithVersion>$([System.String]::Copy('$(SdkPropsContent)').Replace('__VERSION__', '$(Version)'))</SdkPropsContentWithVersion>
+        <SdkPropsContentWithVersion>$([System.String]::Copy('$(SdkPropsContent)').Replace('__VERSION__', '$(Version)').Replace('__IncludeAdditionalFiles__', '$(DollarSign)(IncludeAdditionalFiles)').Replace('__ExcludeAdditionalFiles__', '$(DollarSign)(ExcludeAdditionalFiles)'))</SdkPropsContentWithVersion>
       </PropertyGroup>
     
     <!-- Ensure directories exist -->

--- a/src/Cake.Sdk/README.md
+++ b/src/Cake.Sdk/README.md
@@ -40,7 +40,17 @@ Task("Default")
 RunTarget(target);
 ```
 
-#### Single file based example
+#### Execute example
+
+```bash
+dotnet run --project [path to csproj] -- [arguments]
+```
+i.e.
+```bash
+dotnet run --project build/build.csproj -- --target=Build
+```
+
+#### Single file-based Cake app example
 
 Here's a minimal example using the single file approach:
 
@@ -56,6 +66,75 @@ Task("Default")
 });
 
 RunTarget(target);
+```
+
+To execute a single file-based app:
+```bash
+dotnet run [path to cs file] -- [arguments]
+```
+i.e.
+```bash
+dotnet run build.cs -- --target=Build
+```
+
+> **Note**: File-based Cake apps require .NET 10 or later.
+
+#### Multi-file structure for file-based Cake apps
+
+For larger file-based Cake apps, you can organize your code into multiple files. Use the `IncludeAdditionalFiles` and `ExcludeAdditionalFiles` properties to control which files are included during compilation. This allows you to place models, utility functions, and other code in separate files.
+
+**build.cs**
+```csharp
+#:sdk Cake.Sdk
+#:property IncludeAdditionalFiles build/**/*.cs
+#:property ExcludeAdditionalFiles build/**/Except*.cs
+
+var target = Argument("target", "Default");
+var config = new BuildConfiguration 
+{ 
+    ProjectName = "MyProject",
+    Version = "1.0.0" 
+};
+
+Task("Default")
+    .Does(() =>
+{
+    BuildUtilities.LogInfo($"Building {config.ProjectName} v{config.Version}");
+});
+
+RunTarget(target);
+```
+
+This will include all `.cs` files in the `build` directory...
+
+**build/Models.cs**
+```csharp
+public class BuildConfiguration
+{
+    public string ProjectName { get; set; } = "";
+    public string Version { get; set; } = "";
+}
+```
+
+**build/Utilities.cs**
+```csharp
+public static partial class Program
+{
+    public static void LogInfo(string message)
+    {
+        Information($"INFO: {message}");
+    }
+}
+```
+
+...except for files that match the `ExcludeAdditionalFiles` pattern.
+
+**build/ExceptThisFile.cs**
+```csharp
+// This class will not be compiled.
+public class UnusedLogic
+{
+}
 ```
 
 ### Source Generation


### PR DESCRIPTION
This commit introduces support for multi-file structures in file-based Cake apps.

Additional source files can now be compiled using the `IncludeAdditionalFiles` and `ExcludeAdditionalFiles` properties, which can be set via the `#:property` directive.

- **SDK**: Updated `Cake.Sdk` to conditionally compile files based on the new MSBuild properties.
- **Docs**: Updated `README.md` to document the new multi-file feature and add execution examples.
- **Tests**: Added integration tests to validate file inclusion and exclusion logic.