### PR TITLE
feat: add NuGet package publishing with CI/CD workflow detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
 
       - name: Build Cake Generator & SDK
         uses: cake-build/cake-action@master
+        env:
+          AZURE_DEVOPS_NUGET_API_KEY: ${{ secrets.AZURE_DEVOPS_NUGET_API_KEY }}
+          AZURE_DEVOPS_NUGET_API_URL: ${{ secrets.AZURE_DEVOPS_NUGET_API_URL }}
         with:
           project-path: src/Cake.Generator.TestApp/Cake.Generator.TestApp.csproj
           target: GitHubActions

--- a/src/Cake.Generator.Core/CakeGenerator.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.cs
@@ -18,7 +18,7 @@ public partial class CakeGenerator : IIncrementalGenerator
     {
         // Create a provider that collects all compilation data we need
         var compilationProvider = context.CompilationProvider
-            .Select<Compilation, (Compilation compilation, ImmutableArray<MethodInfo>? methods, ImmutableArray<ModuleInfo>? modules)>((compilation, cancellationToken) =>
+            .Select<Compilation, (Compilation Compilation, ImmutableArray<MethodInfo>? Methods, ImmutableArray<ModuleInfo>? Modules)>((compilation, cancellationToken) =>
             {
                 var extensionAttributeSymbol = compilation.GetTypeByMetadataName(ExtensionAttributeFullName);
                 var cakeMethodAliasAttributeSymbol = compilation.GetTypeByMetadataName(CakeMethodAliasAttributeFullName);

--- a/src/Cake.Generator.TestApp/Models/BuildData.cs
+++ b/src/Cake.Generator.TestApp/Models/BuildData.cs
@@ -1,16 +1,25 @@
 namespace Cake.Generator.TestApp.Models;
 
-#pragma warning disable SA1011 // Closing square brackets should be spaced correctly
-#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
 public record BuildData(
     string Version,
     string BranchName,
+    bool IsPullRequest,
     bool IsMainBranch,
+    bool IsDevelopmentBranch,
+    bool IsFork,
+    bool IsRunningOnGitHubActions,
+    bool IsRunningOnWindows,
     DirectoryPath ArtifactsDirectory,
     FilePath SolutionPath,
-    DotNetMSBuildSettings MSBuildSettings)
+    DotNetMSBuildSettings MSBuildSettings,
+    NuGetPublishSettings NuGetPublishSettings)
     : IToolSettings
 {
+    public bool ShouldPushNuGet { get; } = IsRunningOnGitHubActions
+                                            && IsRunningOnWindows
+                                            && !IsPullRequest
+                                            && !IsFork
+                                            && (IsMainBranch || IsDevelopmentBranch);
     public DirectoryPath OutputDirectory { get; } = ArtifactsDirectory.Combine(Version);
     public DirectoryPath IntegrationTestDirectory { get; } = ArtifactsDirectory.Combine(Version).Combine("IntegrationTest");
 

--- a/src/Cake.Generator.TestApp/Models/NuGetPublishSettings.cs
+++ b/src/Cake.Generator.TestApp/Models/NuGetPublishSettings.cs
@@ -1,0 +1,46 @@
+namespace Cake.Generator.TestApp.Models;
+
+public class NuGetPublishSettings(
+    bool isMainBranch,
+    ICakeEnvironment environment)
+{
+    public DotNetNuGetPushSettings[] Settings { get; } =
+        [
+            ..
+            new (string Name, bool OnlyMain, string? ApiKey, string? Source)[]
+            {
+                (
+                    Name: "NuGet.org",
+                    OnlyMain: true,
+                    ApiKey: environment.GetEnvironmentVariable("NUGET_API_KEY"),
+                    Source: environment.GetEnvironmentVariable("NUGET_API_URL")),
+                (
+                    Name: "Azure DevOps",
+                    OnlyMain: false,
+                    ApiKey: environment.GetEnvironmentVariable("AZURE_DEVOPS_NUGET_API_KEY"),
+                    Source: environment.GetEnvironmentVariable("AZURE_DEVOPS_NUGET_API_URL"))
+            }
+            .Where(x => x.OnlyMain == isMainBranch || !x.OnlyMain)
+            .Select(x =>
+                {
+                    if (isMainBranch)
+                    {
+                        if (string.IsNullOrWhiteSpace(x.ApiKey))
+                        {
+                            throw new InvalidOperationException($"API key for {x.Name} is not set. Please set the environment variable for {x.Name}.");
+                        }
+                        if (string.IsNullOrWhiteSpace(x.Source))
+                        {
+                            throw new InvalidOperationException($"Source URL for {x.Name} is not set. Please set the environment variable for {x.Name}.");
+                        }
+                    }
+
+                    return new DotNetNuGetPushSettings
+                    {
+                        ApiKey = x.ApiKey,
+                        Source = x.Source,
+                        SkipDuplicate = true
+                    };
+                })
+        ];
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,14 +6,14 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageVersion Include="Cake.Core" Version="5.0.0" />
     <PackageVersion Include="Cake.Common" Version="5.0.0" />
     <PackageVersion Include="Cake.Cli" Version="5.0.0" />
     <PackageVersion Include="Cake.DotNetTool.Module" Version="5.0.0" />
     <PackageVersion Include="Cake.NuGet" Version="5.0.0" />
     <PackageVersion Include="Cake.Twitter" Version="5.0.0" />
-    <PackageVersion Include="Cake.BuildSystems.Module" Version="7.1.0" />
+    <PackageVersion Include="Cake.BuildSystems.Module" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
@@ -23,7 +23,7 @@
     <PackageVersion Include="xunit.v3" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Verify.XunitV3" Version="30.3.1" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.4.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add NuGetPublishSettings class for configurable package publishing
- Enhance BuildData with CI/CD workflow detection properties
- Add ShouldPushNuGet logic to control when packages are published
- Implement Publish-NuGet-Packages task with multi-source support
- Update GitHub Actions workflow to include package publishing
- Fix tuple property naming convention in CakeGenerator
- Update package dependencies to latest versions