### PR TITLE
Simplify NuGet source configuration by removing OnlyMain property

### DIFF
--- a/src/Cake.Generator.TestApp/Models/NuGetPublishSettings.cs
+++ b/src/Cake.Generator.TestApp/Models/NuGetPublishSettings.cs
@@ -12,13 +12,11 @@ public class NuGetPublishSettings(
                 {
                         new(
                             Name: "nuget",
-                            OnlyMain: false,
                             OnlyTagged: true,
                             ApiKey: environment.GetEnvironmentVariable("NUGET_API_KEY"),
                             Source: environment.GetEnvironmentVariable("NUGET_API_URL")),
                         new(
                             Name: "AzureDevOps",
-                            OnlyMain: false,
                             OnlyTagged: false,
                             ApiKey: "AzureDevOps",
                             UserName: "AzureDevOps",
@@ -26,9 +24,8 @@ public class NuGetPublishSettings(
                             Source: environment.GetEnvironmentVariable("AZURE_DEVOPS_NUGET_API_URL"),
                             OnlyPush: true)
                 }
-                .Where(x => x.OnlyMain == isMainBranch
-                || x.OnlyTagged == isTagged
-                || (!x.OnlyMain && !x.OnlyTagged))
+                .Where(x => x.OnlyTagged == isTagged
+                            || !x.OnlyTagged)
             ];
 
     private DotNetNuGetPushSettings[]? settings;
@@ -62,7 +59,6 @@ public class NuGetPublishSettings(
 
 public record struct NuGetSource(
     string Name,
-    bool OnlyMain,
     bool OnlyTagged,
     string? Source,
     string? ApiKey = null,


### PR DESCRIPTION
- Remove `OnlyMain` property from `NuGetSource` record struct
- Simplify filtering logic to use only `OnlyTagged` property
- Update NuGet.org source to use `OnlyTagged: true` instead of `OnlyMain: false`
- Update AzureDevOps source to use `OnlyTagged: false` instead of `OnlyMain: false`
- Streamline source selection logic in `NuGetPublishSettings`