### PR TITLE
feat: add cakemultifile template for multi-file Cake builds

### DIFF
--- a/src/Cake.Generator.TestApp/Models/IntegrationTestData.cs
+++ b/src/Cake.Generator.TestApp/Models/IntegrationTestData.cs
@@ -25,6 +25,7 @@ public record IntegrationTestData(
     public DirectoryPath CakeTemplateBuild { get; } = BaseDirectory.Combine("cake.template").Combine("cake");
     public FilePath CakeTemplateBuildCsproj { get; } = BaseDirectory.Combine("cake.template").Combine("cake").CombineWithFilePath("cake.csproj");
     public DirectoryPath CakeTemplateSrc { get; } = BaseDirectory.Combine("cake.template").Combine("src");
+    public FilePath CakeTemplateBuildMultiCs { get; } = BaseDirectory.Combine("cake.template").CombineWithFilePath("cakemultifile.cs");
 
     // New multi-file test properties
     public FilePath CakeSdkFilesCs { get; } = BaseDirectory.CombineWithFilePath("cake.sdk.files.cs");
@@ -41,6 +42,7 @@ public record IntegrationTestData(
             CakeSdkCpmProjectCsproj,
             CakeTemplateBuildCs,
             CakeTemplateBuildCsproj,
+            CakeTemplateBuildMultiCs,
             CakeSdkFilesCs
         ];
 

--- a/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestPrepareTemplate.cs
+++ b/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestPrepareTemplate.cs
@@ -4,6 +4,7 @@ public static partial class Program
     {
         data.DotNet($"new install {data.OutputDirectory.CombineWithFilePath($"Cake.Template.{data.Version}.nupkg")} --force");
         data.DotNet($"new cakefile --name cake --output {data.IntegrationTest.CakeTemplate}");
+        data.DotNet($"new cakemultifile --name cakemultifile --output {data.IntegrationTest.CakeTemplate}");
         data.DotNet($"new cakeproj --name cake --output {data.IntegrationTest.CakeTemplate}");
         data.DotNet($"new uninstall Cake.Template");
 

--- a/src/Cake.Sdk/README.md
+++ b/src/Cake.Sdk/README.md
@@ -86,8 +86,8 @@ For larger file-based Cake apps, you can organize your code into multiple files.
 **build.cs**
 ```csharp
 #:sdk Cake.Sdk
-#:property IncludeAdditionalFiles build/**/*.cs
-#:property ExcludeAdditionalFiles build/**/Except*.cs
+#:property IncludeAdditionalFiles=build/**/*.cs
+#:property ExcludeAdditionalFiles=build/**/Except*.cs
 
 var target = Argument("target", "Default");
 var config = new BuildConfiguration 

--- a/src/Cake.Template/README.md
+++ b/src/Cake.Template/README.md
@@ -9,6 +9,11 @@ This package contains templates for creating Cake build scripts and projects usi
 - **Description**: Creates a Cake build script using the file-based approach with `#:sdk Cake.Sdk` directive
 - **Usage**: `dotnet new cakefile`
 
+### Cake SDK Multi-file File-based
+- **Short name**: `cakemultifile`
+- **Description**: Creates a Cake build script using the multi-file structure approach with `#:sdk Cake.Sdk` directive
+- **Usage**: `dotnet new cakemultifile`
+
 ### Cake SDK Project-based
 - **Short name**: `cakeproj`
 - **Description**: Creates a Cake build project using the project-based approach with Cake.Sdk
@@ -18,9 +23,14 @@ This package contains templates for creating Cake build scripts and projects usi
 
 #### Examples
 
-Create a file-based build script:
+Create a file-based build script (requires .NET 10):
 ```bash
 dotnet new cakefile
+```
+
+Create a multi-file file-based build script (requires .NET 10):
+```bash
+dotnet new cakemultifile
 ```
 
 Create a project-based build targeting .NET 8.0:

--- a/src/Cake.Template/templates/cakemultifile/.template.config/template.json
+++ b/src/Cake.Template/templates/cakemultifile/.template.config/template.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Cake Contributors",
+  "classifications": [
+    "Console",
+    "Cake",
+    "Build"
+  ],
+  "name": "Cake SDK Multi-file File-based",
+  "description": "A Cake build script using multi-file structure with Cake.Sdk",
+  "identity": "Cake.Sdk.File.Multifile",
+  "groupIdentity": "Cake.Sdk.File.Multifile",
+  "shortName": "cakemultifile",
+  "sourceName": "cakemultifile",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "preferNameDirectory": false,
+  "primaryOutputs": [
+    {
+      "path": "build.cs"
+    },
+    {
+      "path": "build/Models.cs"
+    },
+    {
+      "path": "build/Utilities.cs"
+    }
+  ]
+} 

--- a/src/Cake.Template/templates/cakemultifile/build/ExceptThisFile.cs
+++ b/src/Cake.Template/templates/cakemultifile/build/ExceptThisFile.cs
@@ -1,0 +1,9 @@
+// This class will not be compiled due to the ExcludeAdditionalFiles pattern.
+// Files matching "build/**/Except*.cs" are excluded from compilation.
+public class UnusedLogic
+{
+    public void DoSomething()
+    {
+        // This code will not be included in the build
+    }
+} 

--- a/src/Cake.Template/templates/cakemultifile/build/Models.cs
+++ b/src/Cake.Template/templates/cakemultifile/build/Models.cs
@@ -1,0 +1,5 @@
+public record BuildConfiguration(
+    string ProjectName = "",
+    string Version = "",
+    string Configuration = "Release"
+); 

--- a/src/Cake.Template/templates/cakemultifile/build/Utilities.cs
+++ b/src/Cake.Template/templates/cakemultifile/build/Utilities.cs
@@ -1,0 +1,20 @@
+public static partial class Program
+{
+    public static class BuildUtilities
+    {
+        public static void LogInfo(string message)
+        {
+            Information($"INFO: {message}");
+        }
+        
+        public static void LogWarning(string message)
+        {
+            Warning($"WARNING: {message}");
+        }
+        
+        public static void LogError(string message)
+        {
+            Error($"ERROR: {message}");
+        }
+    }
+} 

--- a/src/Cake.Template/templates/cakemultifile/cakemultifile.cs
+++ b/src/Cake.Template/templates/cakemultifile/cakemultifile.cs
@@ -1,0 +1,59 @@
+#:sdk Cake.Sdk
+#:property IncludeAdditionalFiles=build/**/*.cs
+#:property ExcludeAdditionalFiles=build/**/Except*.cs
+
+var target = Argument("target", "Default");
+
+Setup(context => new BuildConfiguration(
+    ProjectName: "MyProject",
+    Version: "1.0.0",
+    Configuration: Argument("configuration", "Release")
+));
+
+//////////////////////////////////////////////////////////////////////
+// TASKS
+//////////////////////////////////////////////////////////////////////
+
+Task("Clean")
+    .WithCriteria(c => HasArgument("rebuild"))
+    .Does<BuildConfiguration>(static (context, config) =>
+{
+    BuildUtilities.LogInfo("Cleaning build artifacts...");
+    CleanDirectory($"./src/Example/bin/{config.Configuration}");
+});
+
+Task("Build")
+    .IsDependentOn("Clean")
+    .Does<BuildConfiguration>(static (context, config) =>
+{
+    BuildUtilities.LogInfo($"Building {config.ProjectName} v{config.Version}");
+    DotNetBuild("./src/Example.sln", new DotNetBuildSettings
+    {
+        Configuration = config.Configuration,
+    });
+});
+
+Task("Test")
+    .IsDependentOn("Build")
+    .Does<BuildConfiguration>(static (context, config) =>
+{
+    BuildUtilities.LogInfo("Running tests...");
+    DotNetTest("./src/Example.sln", new DotNetTestSettings
+    {
+        Configuration = config.Configuration,
+        NoBuild = true,
+    });
+});
+
+Task("Default")
+    .IsDependentOn("Test")
+    .Does(() =>
+{
+    BuildUtilities.LogInfo("Default task completed successfully!");
+});
+
+//////////////////////////////////////////////////////////////////////
+// EXECUTION
+//////////////////////////////////////////////////////////////////////
+
+RunTarget(target); 


### PR DESCRIPTION
- Add cakemultifile template with build/Models.cs, Utilities.cs, ExceptThisFile.cs
- Include template in integration tests
- Fix property syntax in SDK README examples
- Update template documentation