### PR TITLE
fix: disable AOT publishing for Cake.Sdk

### DIFF
--- a/src/Cake.Sdk/Cake.Sdk.csproj
+++ b/src/Cake.Sdk/Cake.Sdk.csproj
@@ -40,6 +40,7 @@
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
+    <PublishAot>false</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Sdk/README.md
+++ b/src/Cake.Sdk/README.md
@@ -186,6 +186,7 @@ The Cake.Sdk automatically configures the following properties:
 - `DebugType`: portable
 - `DebugSymbols`: true
 - `LangVersion`: latest
+- `PublishAot`: false 
 
 ## Requirements
 


### PR DESCRIPTION
Add PublishAot=false property to prevent AOT compilation issues