### PR TITLE
fix: enable JSON reflection by default for Cake.Sdk

### DIFF
--- a/src/Cake.Sdk/Cake.Sdk.csproj
+++ b/src/Cake.Sdk/Cake.Sdk.csproj
@@ -41,6 +41,7 @@
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
     <PublishAot>false</PublishAot>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Sdk/README.md
+++ b/src/Cake.Sdk/README.md
@@ -187,6 +187,7 @@ The Cake.Sdk automatically configures the following properties:
 - `DebugSymbols`: true
 - `LangVersion`: latest
 - `PublishAot`: false 
+- `JsonSerializerIsReflectionEnabledByDefault`: true
 
 ## Requirements
 


### PR DESCRIPTION
- Add JsonSerializerIsReflectionEnabledByDefault=true to project properties
- Update README to document the JSON serializer configuration
- Ensures JSON serialization works correctly in Cake build scripts