### PR TITLE
feat: Add cakeglobaljson template for global.json generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -485,3 +485,5 @@ $RECYCLE.BIN/
 
 # Tools
 [Tt]ools/
+
+src/Cake.Template/templates/cakeglobaljson/.template.config/template.json

--- a/src/Cake.Generator.TestApp/Program.cs
+++ b/src/Cake.Generator.TestApp/Program.cs
@@ -39,8 +39,12 @@ Task("IntegrationTest-Setup")
         Verbosity.Diagnostic,
         IntegrationTestSetup);
 
-Task("IntegrationTest-PrepareAppCs")
+Task("IntegrationTest-PrepareTemplate")
     .IsDependentOn("IntegrationTest-Setup")
+    .Does<BuildData>(IntegrationTestPrepareTemplate);
+
+Task("IntegrationTest-PrepareAppCs")
+    .IsDependentOn("IntegrationTest-PrepareTemplate")
     .Does<BuildData>(IntegrationTestPrepareAppCs);
 
 Task("IntegrationTest-PrepareMultiFile")
@@ -53,12 +57,8 @@ Task("IntegrationTest-PrepareProjects")
         Verbosity.Diagnostic,
         IntegrationTestPrepareProjects);
 
-Task("IntegrationTest-PrepareTemplate")
-    .IsDependentOn("IntegrationTest-PrepareProjects")
-    .Does<BuildData>(IntegrationTestPrepareTemplate);
-
 Task("IntegrationTest-UploadTestCases-Artifacts")
-    .IsDependentOn("IntegrationTest-PrepareTemplate")
+    .IsDependentOn("IntegrationTest-PrepareProjects")
     .WithCriteria(GitHubActions.IsRunningOnGitHubActions, nameof(GitHubActions.IsRunningOnGitHubActions))
     .Does<BuildData>(IntegrationTestUploadTestCasesArtifacts);
 

--- a/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestPrepareTemplate.cs
+++ b/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestPrepareTemplate.cs
@@ -3,6 +3,9 @@ public static partial class Program
     private static void IntegrationTestPrepareTemplate(ICakeContext ctx, BuildData data)
     {
         data.DotNet($"new install {data.OutputDirectory.CombineWithFilePath($"Cake.Template.{data.Version}.nupkg")} --force");
+
+        data.DotNet("new cakeglobaljson");
+
         data.DotNet($"new cakefile --name cake --output {data.IntegrationTest.CakeTemplate}");
         data.DotNet($"new cakemultifile --name cakemultifile --output {data.IntegrationTest.CakeTemplate}");
         data.DotNet($"new cakeproj --name cake --output {data.IntegrationTest.CakeTemplate}");

--- a/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestSetup.cs
+++ b/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestSetup.cs
@@ -1,38 +1,7 @@
 public static partial class Program
 {
-    private static async Task IntegrationTestSetup(ICakeContext ctx, BuildData data)
+    private static void IntegrationTestSetup(ICakeContext ctx, BuildData data)
     {
-        data.DotNet("new globaljson");
-
-        Information("Adding Cake.Sdk to global.json msbuild-sdks");
-        using (var globalJsonStream = Context.FileSystem.GetFile(data.IntegrationTest.GlobalJson).Open(FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
-        {
-            var currentConfig = await JsonSerializer.DeserializeAsync<ConcurrentDictionary<string, Dictionary<string, string>>>(globalJsonStream);
-            ArgumentNullException.ThrowIfNull(currentConfig);
-
-            currentConfig.AddOrUpdate(
-                "msbuild-sdks",
-                add => new()
-                    {
-                        { "Cake.Sdk", data.Version }
-                    },
-                (key, update) =>
-                    {
-                        update["Cake.Sdk"] = data.Version;
-                        return update;
-                    });
-
-            globalJsonStream.Position = 0;
-
-            await JsonSerializer.SerializeAsync(
-                globalJsonStream,
-                currentConfig,
-                options: new()
-                {
-                    WriteIndented = true,
-                });
-        }
-
         data.DotNet("new nugetconfig");
 
         data.DotNet($"nuget add source --name local \"{data.OutputDirectory.FullPath.Replace('/', System.IO.Path.DirectorySeparatorChar)}\"");

--- a/src/Cake.Template/Cake.Template.csproj
+++ b/src/Cake.Template/Cake.Template.csproj
@@ -24,4 +24,53 @@
     <XmlPoke XmlInputPath="templates\cakeproj\cakeproj\cakeproj.csproj" Query="Project/@Sdk" Value="Cake.Sdk/$(TemplateVersion)" />
   </Target>
 
+  <Target Name="UpdateCakeGlobalJsonTemplate" BeforeTargets="PrepareForBuild">
+    <!-- Generate the template.json content with replaced placeholders -->
+    <PropertyGroup>
+      <TemplateJsonContent><![CDATA[{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Cake Contributors",
+  "classifications": [
+    "Config",
+    "Cake",
+    "Build"
+  ],
+  "name": "Cake SDK Global.json",
+  "description": "A global.json file for Cake projects using Cake.Sdk with version placeholders",
+  "identity": "Cake.Sdk.GlobalJson",
+  "groupIdentity": "Cake.Sdk.GlobalJson",
+  "shortName": "cakeglobaljson",
+  "sourceName": "cakeglobaljson",
+  "tags": {
+    "language": "JSON",
+    "type": "item"
+  },
+  "preferNameDirectory": false,
+  "primaryOutputs": [
+    {
+      "path": "global.json"
+    }
+  ],
+  "symbols": {
+    "SdkVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "The .NET SDK version to use",
+      "defaultValue": "$(SdkVersion)",
+      "replaces": "SdkVersion"
+    },
+    "CakeSdkVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "The Cake.Sdk version to use",
+      "defaultValue": "$(Version)",
+      "replaces": "CakeSdkVersion"
+    }
+  }
+}]]></TemplateJsonContent>
+    </PropertyGroup>
+    <!-- Write the updated template.json -->
+    <WriteLinesToFile File="templates\cakeglobaljson\.template.config\template.json" Lines="$(TemplateJsonContent)" Overwrite="true" />
+  </Target>
+
 </Project> 

--- a/src/Cake.Template/templates/cakeglobaljson/global.json
+++ b/src/Cake.Template/templates/cakeglobaljson/global.json
@@ -1,0 +1,8 @@
+{
+  "sdk": {
+    "version": "SdkVersion"
+  },
+  "msbuild-sdks": {
+    "Cake.Sdk": "CakeSdkVersion"
+  }
+}


### PR DESCRIPTION
- Add new cakeglobaljson template that generates global.json with SDK version placeholders
- Template includes SdkVersion and CakeSdkVersion parameters with defaults from MSBuild properties
- Add MSBuild target to update template.json with current SDK and Cake.Sdk versions during build
- Integrate template into integration test pipeline
- Add SDK version reading from root global.json using System.Text.Json
- Update build process to pass SDK version to MSBuild settings
- Exclude generated template.json from git tracking
