### PR TITLE
Treat warnings as errors, add warning suppressions for trimming and reflection usage

### DIFF
--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeModules.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeModules.g.verified.cs
@@ -73,12 +73,14 @@ public static partial class Program
             public ICakeRegistrationBuilder RegisterInstance<TImplementation>(TImplementation instance)
                 where TImplementation : class
             {
+#pragma warning disable IL2087 // 'TImplementation' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'ServiceRegistration.ServiceRegistration(Type)'
                 var registration = new ServiceRegistration(typeof(TImplementation))
                 {
                     Instance = instance,
                     Lifetime = ServiceLifetime.Singleton,
                     ServiceType = typeof(TImplementation),
                 };
+#pragma warning restore IL2087
 
                 _registrations.Add(registration);
                 return registration;

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.Modules.ServiceCollectionAdapter.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.Modules.ServiceCollectionAdapter.cs
@@ -56,12 +56,14 @@ public partial class CakeGenerator
                         public ICakeRegistrationBuilder RegisterInstance<TImplementation>(TImplementation instance)
                             where TImplementation : class
                         {
+            #pragma warning disable IL2087 // 'TImplementation' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'ServiceRegistration.ServiceRegistration(Type)'
                             var registration = new ServiceRegistration(typeof(TImplementation))
                             {
                                 Instance = instance,
                                 Lifetime = ServiceLifetime.Singleton,
                                 ServiceType = typeof(TImplementation),
                             };
+            #pragma warning restore IL2087
 
                             _registrations.Add(registration);
                             return registration;

--- a/src/Cake.Generator.TestApp/Models/IntegrationTestData.cs
+++ b/src/Cake.Generator.TestApp/Models/IntegrationTestData.cs
@@ -170,9 +170,11 @@ public record IntegrationTestData(
                     Assert.Equal(data.ExpectedVersion, data.Version);
                     Assert.Equal(data.ExpectedVersion, CakeGeneratorNuGetVersion);
 
-                    // Verify that the excluded class is not available using reflection
-                    var assembly = typeof(BuildConfiguration).Assembly;
-                    var typeExists = assembly.GetTypes().Any(t => t.Name == "ExcludedClass");
+                                         // Verify that the excluded class is not available using reflection
+                     var assembly = typeof(BuildConfiguration).Assembly;
+        #pragma warning disable IL2026 // Using member 'System.Reflection.Assembly.GetTypes()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code
+                     var typeExists = assembly.GetTypes().Any(t => t.Name == "ExcludedClass");
+        #pragma warning restore IL2026
 
                     Assert.False(typeExists, "The type 'ExcludedClass' should not exist in the assembly.");
                 });

--- a/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestExecute.cs
+++ b/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestExecute.cs
@@ -14,7 +14,7 @@ public static partial class Program
                 data with {
                     WorkingDirectory = file.GetDirectory()
                 },
-                $"{mode}{file} -- --integration-test-version={data.Version}");
+                $"{mode}{file} -p:TreatWarningsAsErrors=true -- --integration-test-version={data.Version}");
         }
     }
 }

--- a/src/Cake.Generator.TestApp/Program/Program.Setup.cs
+++ b/src/Cake.Generator.TestApp/Program/Program.Setup.cs
@@ -48,7 +48,7 @@ public static partial class Program
         var msBuildSettings = new DotNetMSBuildSettings()
                 .SetConfiguration("IntegrationTest")
                 .SetVersion(version)
-                .WithProperty("WarningAsError", "true")
+                .WithProperty("TreatWarningsAsErrors", "true")
                 .WithProperty("NoWarn", "NU5104;NU5128;NETSDK1057")
                 .WithProperty("SdkVersion", sdkVersion);
 


### PR DESCRIPTION
- Add IL2087 warning suppression for RegisterInstance method to handle interface compatibility
- Add IL2026 warning suppression for Assembly.GetTypes() in integration test
- Update test execution to use TreatWarningsAsErrors property instead of WarningAsError
- Add TreatWarningsAsErrors=true also for integration tests