### PR TITLE
feat: migrate from xUnit to TUnit

### DIFF
--- a/src/Cake.Generator.Core.Tests/Cake.Generator.Core.Tests.csproj
+++ b/src/Cake.Generator.Core.Tests/Cake.Generator.Core.Tests.csproj
@@ -17,13 +17,12 @@
     <PackageReference Include="Cake.Common" GeneratePathProperty="true" />
     <PackageReference Include="Cake.BuildSystems.Module" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
+    <PackageReference Include="TUnit" />
     <PackageReference Include="Verify.DiffPlex" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Verify.SourceGenerators" />
+    <PackageReference Include="Verify.TUnit" />
 
     <None Include="$(PkgCake_Core)\lib\net8.0\Cake.Core.xml" Visible="false">
       <Link>%(Filename)%(Extension)</Link>
@@ -58,9 +57,9 @@
     <Using Include="System.Linq" />
     <Using Include="System.Text" />
     <Using Include="System.Threading.Tasks" />
-    <Using Include="Xunit" />
+    <Using Include="TUnit" />
     <Using Include="VerifyTests" />
-    <Using Include="VerifyXunit" />
+    <Using Include="VerifyTUnit" />
     <Using Include="Cake.Generator" />
     <Using Include="System.ComponentModel" />
   </ItemGroup>

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.cs
@@ -1,51 +1,43 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 namespace Cake.Generator.Core.Tests.Unit;
-
 /// <summary>
 /// Tests for the main <see cref="CakeGenerator"/> functionality.
 /// </summary>
 public sealed class CakeGeneratorTests
 {
-    [Fact]
-    public async Task RunGenerators()
+    [Test]
+    public async Task RunGenerators(CancellationToken cancellationToken)
     {
         // Given
         var source = CakeGeneratorTestsBase.CommonSources.Program;
         var compilation = CakeGeneratorTestsBase.CreateCakeCompilation(source);
-
         // When
         var driver = CSharpGeneratorDriver.Create(new CakeGenerator());
-        var result = driver.RunGenerators(compilation, TestContext.Current.CancellationToken);
-
+        var result = driver.RunGenerators(compilation, cancellationToken);
         // Then
         await Verify(result.GetRunResult());
     }
 
-    [Fact]
-    public async Task RunGenerators_WithModules()
+    [Test]
+    public async Task RunGenerators_WithModules(CancellationToken cancellationToken)
     {
         // Given
         var source = CakeGeneratorTestsBase.CommonSources.Program;
-
         // Add the BuildSystems.Module assembly reference to test module detection
         var buildSystemsModuleLocation = typeof(GitHubActions.Module.GitHubActionsModule).Assembly.Location;
         var moduleReference = MetadataReference.CreateFromFile(buildSystemsModuleLocation);
-
         var compilation = CakeGeneratorTestsBase.CreateCompilation(source, moduleReference);
-
         // When
         var driver = CSharpGeneratorDriver.Create(new CakeGenerator());
-        var result = driver.RunGenerators(compilation, TestContext.Current.CancellationToken);
-
+        var result = driver.RunGenerators(compilation, cancellationToken);
         // Then
         await Verify(result.GetRunResult());
     }
 
-    [Fact]
-    public async Task RunGenerators_WithMainMethods_GeneratesMainMethodCalls()
+    [Test]
+    public async Task RunGenerators_WithMainMethods_GeneratesMainMethodCalls(CancellationToken cancellationToken)
     {
         // Given
         var source = """
@@ -70,17 +62,13 @@ public sealed class CakeGeneratorTests
             }
         }
         """;
-
         var compilation = CakeGeneratorTestsBase.CreateCakeCompilation(source);
-
         // When
         var driver = CSharpGeneratorDriver.Create(new CakeGenerator());
-        var result = driver.RunGenerators(compilation, TestContext.Current.CancellationToken);
-
+        var result = driver.RunGenerators(compilation, cancellationToken);
         // Then
         var runResult = result.GetRunResult();
         var generatedCode = string.Join("\n", runResult.Results.SelectMany(r => r.GeneratedSources).Select(s => s.SourceText.ToString()));
-
         await Verify(runResult);
     }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,12 +18,12 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <!-- Test dependencies -->
-    <PackageVersion Include="xunit.v3" Version="3.0.0" />
+    <PackageVersion Include="TUnit" Version="0.57.24" />
+    <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
+    <PackageVersion Include="Verify.TUnit" Version="30.10.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Verify.XunitV3" Version="30.6.1" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Replace xUnit packages with TUnit
- Update test attributes from [Fact] to [Test]
- Add CancellationToken parameter to test methods
- Update using statements for TUnit and VerifyTUnit
- Remove xUnit-specific TestContext.Current usage