### PR TITLE
Code cleanup and formatting improvements

### DIFF
--- a/src/Cake.Generator.Core/CakeGenerator.Constants.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Constants.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
-
 namespace Cake.Generator;
 
 public partial class CakeGenerator

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeCli.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeCli.cs
@@ -190,5 +190,5 @@ public partial class CakeGenerator
                 }
             }
             """;
-   }
+    }
 }

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeCore.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeCore.cs
@@ -79,5 +79,5 @@ public partial class CakeGenerator
                 }
             }
             """;
-   }
+    }
 }

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeGenerator.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeGenerator.cs
@@ -46,5 +46,5 @@ public partial class CakeGenerator
                 }
             }
             """;
-   }
+    }
 }

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.Modules.ServiceCollectionAdapter.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.Modules.ServiceCollectionAdapter.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Cake.Generator;
 
 public partial class CakeGenerator

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.ScriptHost.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.ScriptHost.cs
@@ -12,7 +12,7 @@ public partial class CakeGenerator
 
         if (scriptHostInterface == null)
         {
-          return string.Empty;
+            return string.Empty;
         }
 
         // Scan current compilation for Main_ prefixed methods in Program class

--- a/src/Cake.Generator.Core/CakeGenerator.ScanForMainMethods.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.ScanForMainMethods.cs
@@ -6,31 +6,31 @@ namespace Cake.Generator;
 
 public partial class CakeGenerator
 {
-        private static List<string> ScanForMainMethods(Compilation compilation)
+    private static List<string> ScanForMainMethods(Compilation compilation)
+    {
+        var mainMethods = new List<string>();
+
+        // Find the Program type in the current compilation
+        var programType = compilation.GlobalNamespace.GetTypeMembers("Program").FirstOrDefault();
+        if (programType == null)
         {
-            var mainMethods = new List<string>();
-
-            // Find the Program type in the current compilation
-            var programType = compilation.GlobalNamespace.GetTypeMembers("Program").FirstOrDefault();
-            if (programType == null)
-            {
-                return mainMethods;
-            }
-
-            // Scan for static private void methods prefixed with Main_ and no parameters
-            foreach (var member in programType.GetMembers())
-            {
-                if (member is IMethodSymbol methodSymbol &&
-                    methodSymbol.IsStatic &&
-                    methodSymbol.DeclaredAccessibility == Accessibility.Private &&
-                    methodSymbol.ReturnType.SpecialType == SpecialType.System_Void &&
-                    methodSymbol.Parameters.Length == 0 &&
-                    methodSymbol.Name.StartsWith("Main_"))
-                {
-                    mainMethods.Add(methodSymbol.Name);
-                }
-            }
-
             return mainMethods;
         }
+
+        // Scan for static private void methods prefixed with Main_ and no parameters
+        foreach (var member in programType.GetMembers())
+        {
+            if (member is IMethodSymbol methodSymbol &&
+                methodSymbol.IsStatic &&
+                methodSymbol.DeclaredAccessibility == Accessibility.Private &&
+                methodSymbol.ReturnType.SpecialType == SpecialType.System_Void &&
+                methodSymbol.Parameters.Length == 0 &&
+                methodSymbol.Name.StartsWith("Main_"))
+            {
+                mainMethods.Add(methodSymbol.Name);
+            }
+        }
+
+        return mainMethods;
+    }
 }

--- a/src/Cake.Generator.TestApp/Program.Helper.cs
+++ b/src/Cake.Generator.TestApp/Program.Helper.cs
@@ -50,7 +50,8 @@ public static partial class Program
                                         args.Format,
                                         args
                                             .GetArguments()
-                                            .Select(value => value switch {
+                                            .Select(value => value switch
+                                            {
                                                 string s when s.Contains(' ')
                                                     => s.Quote(),
                                                 Cake.Core.IO.Path path

--- a/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestExecute.cs
+++ b/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestExecute.cs
@@ -11,7 +11,8 @@ public static partial class Program
 
             var mode = file.GetExtension() == ".csproj" ? "run --project " : string.Empty;
             DotNet(
-                data with {
+                data with
+                {
                     WorkingDirectory = file.GetDirectory()
                 },
                 $"{mode}{file} -p:TreatWarningsAsErrors=true -- --integration-test-version={data.Version}");

--- a/src/Cake.Generator.TestApp/Program/Program.Clean.cs
+++ b/src/Cake.Generator.TestApp/Program/Program.Clean.cs
@@ -2,6 +2,6 @@ public static partial class Program
 {
     private static void Clean(ICakeContext ctx, BuildData data)
     {
-       CleanDirectories(data.PathsToClean);
+        CleanDirectories(data.PathsToClean);
     }
 }


### PR DESCRIPTION
Removed unused `using` directives to reduce unnecessary dependencies. Refactored `ScanForMainMethods` for improved readability and maintainability. Standardized indentation and formatting across multiple files, including `Program.Helper.cs`,
`Program.IntegrationTestExecute.cs`, and `Program.Clean.cs`. These changes enhance code consistency and maintainability without altering functionality.