### PR TITLE
Disable compiler optimizations in Cake.Sdk props

### DIFF
--- a/src/Cake.Sdk/Cake.Sdk.csproj
+++ b/src/Cake.Sdk/Cake.Sdk.csproj
@@ -37,7 +37,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
The `<Optimize>` property in the `Cake.Sdk.csproj` file was changed from `true` to `false`. This disables compiler optimizations, likely to facilitate debugging or testing by making it easier to analyze code behavior during development. Fixes #24