### PR TITLE
feat: Fix Cake.Sdk trimming support&modernize Generator code

### DIFF
--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeCakeAppSettings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeCakeAppSettings.g.verified.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using Spectre.Console.Cli;
 
-internal sealed class CakeAppSettings :  Spectre.Console.Cli.CommandSettings
+internal sealed class CakeAppSettings : Spectre.Console.Cli.CommandSettings
 {
     [CommandOption("--target|-t|--Target <TARGET>")]
     [Description("Target task to invoke.")]

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeCakeAppSettings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeCakeAppSettings.g.verified.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using Spectre.Console.Cli;
 
-internal sealed class CakeAppSettings :  Spectre.Console.Cli.CommandSettings
+internal sealed class CakeAppSettings : Spectre.Console.Cli.CommandSettings
 {
     [CommandOption("--target|-t|--Target <TARGET>")]
     [Description("Target task to invoke.")]

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeCakeAppSettings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeCakeAppSettings.g.verified.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using Spectre.Console.Cli;
 
-internal sealed class CakeAppSettings :  Spectre.Console.Cli.CommandSettings
+internal sealed class CakeAppSettings : Spectre.Console.Cli.CommandSettings
 {
     [CommandOption("--target|-t|--Target <TARGET>")]
     [Description("Target task to invoke.")]

--- a/src/Cake.Generator.Core/Cake.Generator.Core.csproj
+++ b/src/Cake.Generator.Core/Cake.Generator.Core.csproj
@@ -30,4 +30,10 @@
     <Using Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Cake.Generator.Core.BenchmarkSuite</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Cake.Generator.Core/CakeGenerator.Constants.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Constants.cs
@@ -72,21 +72,10 @@ public partial class CakeGenerator
             }
         }
 
-        public readonly struct StringBuilderScope : IDisposable
+        public readonly struct StringBuilderScope(StringBuilder stringBuilder) : IDisposable
         {
-            private readonly StringBuilder _stringBuilder;
-
-            public StringBuilderScope(StringBuilder stringBuilder)
-            {
-                _stringBuilder = stringBuilder;
-            }
-
-            public StringBuilder StringBuilder => _stringBuilder;
-
-            public void Dispose()
-            {
-                StringBuilderCache.Release(_stringBuilder);
-            }
+            public StringBuilder StringBuilder => stringBuilder;
+            public void Dispose() => Release(stringBuilder);
 
             public static implicit operator StringBuilder(StringBuilderScope scope) => scope.StringBuilder;
         }

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.CakeAppSettings.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.CakeAppSettings.cs
@@ -12,7 +12,7 @@ public partial class CakeGenerator
         using System.ComponentModel;
         using Spectre.Console.Cli;
 
-        internal sealed class CakeAppSettings :  Spectre.Console.Cli.CommandSettings
+        internal sealed class CakeAppSettings : Spectre.Console.Cli.CommandSettings
         {
             [CommandOption("--target|-t|--Target <TARGET>")]
             [Description("Target task to invoke.")]

--- a/src/Cake.Generator.Core/CakeGenerator.GroupMethodsByAssemblyName.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.GroupMethodsByAssemblyName.cs
@@ -19,7 +19,7 @@ public partial class CakeGenerator
 
             result.AddOrUpdate(
                 key,
-                _ => new List<MethodInfo> { method },
+                _ => [method],
                 (_, existingList) =>
                 {
                     existingList.Add(method);

--- a/src/Cake.Generator.Core/CakeGenerator.MethodInfo.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.MethodInfo.cs
@@ -6,41 +6,33 @@ namespace Cake.Generator;
 
 public partial class CakeGenerator
 {
-    internal class MethodInfo
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MethodInfo"/> class.
+    /// </summary>
+    /// <param name="symbol">The method symbol.</param>
+    /// <param name="isPropertyAlias">A value indicating whether the method is a property alias.</param>
+    /// <param name="isCached">A value indicating whether the property alias is cached.</param>
+    /// <param name="namespaceImports">The namespaces to import based on CakeNamespaceImportAttribute.</param>
+    internal class MethodInfo(IMethodSymbol symbol, bool isPropertyAlias = false, bool isCached = false, params ImmutableArray<string> namespaceImports)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MethodInfo"/> class.
-        /// </summary>
-        /// <param name="symbol">The method symbol.</param>
-        /// <param name="isPropertyAlias">A value indicating whether the method is a property alias.</param>
-        /// <param name="isCached">A value indicating whether the property alias is cached.</param>
-        /// <param name="namespaceImports">The namespaces to import based on CakeNamespaceImportAttribute.</param>
-        public MethodInfo(IMethodSymbol symbol, bool isPropertyAlias = false, bool isCached = false, params string[] namespaceImports)
-        {
-            this.Symbol = symbol;
-            this.IsPropertyAlias = isPropertyAlias;
-            this.IsCached = isCached;
-            this.NamespaceImports = namespaceImports;
-        }
-
         /// <summary>
         /// Gets the method symbol.
         /// </summary>
-        public IMethodSymbol Symbol { get; }
+        public IMethodSymbol Symbol { get; } = symbol;
 
         /// <summary>
         /// Gets a value indicating whether the method is a property alias.
         /// </summary>
-        public bool IsPropertyAlias { get; }
+        public bool IsPropertyAlias { get; } = isPropertyAlias;
 
         /// <summary>
         /// Gets a value indicating whether the property alias is cached.
         /// </summary>
-        public bool IsCached { get; }
+        public bool IsCached { get; } = isCached;
 
         /// <summary>
         /// Gets the namespaces to import based on CakeNamespaceImportAttribute.
         /// </summary>
-        public string[] NamespaceImports { get; }
+        public ImmutableArray<string> NamespaceImports { get; } = namespaceImports;
     }
 }

--- a/src/Cake.Generator.Core/CakeGenerator.ModuleInfo.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.ModuleInfo.cs
@@ -6,21 +6,16 @@ namespace Cake.Generator;
 
 public partial class CakeGenerator
 {
-    internal class ModuleInfo
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModuleInfo"/> class.
+    /// </summary>
+    /// <param name="symbol">The module type symbol.</param>
+    internal class ModuleInfo(INamedTypeSymbol symbol)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ModuleInfo"/> class.
-        /// </summary>
-        /// <param name="symbol">The module type symbol.</param>
-        public ModuleInfo(INamedTypeSymbol symbol)
-        {
-            Symbol = symbol;
-        }
-
         /// <summary>
         /// Gets the module type symbol.
         /// </summary>
-        public INamedTypeSymbol Symbol { get; }
+        public INamedTypeSymbol Symbol { get; } = symbol;
 
         /// <summary>
         /// Gets the full name of the module type.

--- a/src/Cake.Generator.Core/CakeGenerator.ScanForMainMethods.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.ScanForMainMethods.cs
@@ -8,7 +8,7 @@ public partial class CakeGenerator
 {
     private static List<string> ScanForMainMethods(Compilation compilation)
     {
-        var mainMethods = new List<string>();
+        List<string>? mainMethods = [];
 
         // Find the Program type in the current compilation
         var programType = compilation.GlobalNamespace.GetTypeMembers("Program").FirstOrDefault();

--- a/src/Cake.Generator.Core/CakeGenerator.ScanTypeMembers.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.ScanTypeMembers.cs
@@ -17,7 +17,7 @@ public partial class CakeGenerator
     {
         var validMethods = new List<MethodInfo>();
         ScanNamespaceMembers(namespaceSymbol, cakeMethodAliasAttributeSymbol, cakePropertyAliasAttributeSymbol, cakeNamespaceImportAttributeSymbol, iCakeContextSymbol, validMethods);
-        return validMethods.Count == 0 ? ImmutableArray<MethodInfo>.Empty : validMethods.ToImmutableArray();
+        return validMethods.Count == 0 ? [] : [.. validMethods];
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public partial class CakeGenerator
         }
 
         // Extract namespace imports from CakeNamespaceImportAttribute
-        string[] namespaceImports = Array.Empty<string>();
+        ImmutableArray<string>? namespaceImports = null;
         if (cakeNamespaceImportAttributeSymbol != null)
         {
             List<string>? imports = null;
@@ -160,17 +160,16 @@ public partial class CakeGenerator
                         attr.ConstructorArguments[0].Value is string namespaceValue &&
                         !string.IsNullOrWhiteSpace(namespaceValue))
                     {
-                        imports ??= new List<string>();
-                        imports.Add(namespaceValue);
+                        (imports ??= []).Add(namespaceValue);
                     }
                 }
             }
             if (imports != null)
             {
-                namespaceImports = imports.ToArray();
+                namespaceImports = [..imports];
             }
         }
 
-        return new MethodInfo(methodSymbol, isPropertyAlias, isCached, namespaceImports);
+        return new MethodInfo(methodSymbol, isPropertyAlias, isCached, namespaceImports ?? []);
     }
 }

--- a/src/Cake.Generator.Core/CakeGenerator.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-
 namespace Cake.Generator;
 
 /// <summary>
@@ -105,17 +100,14 @@ public partial class CakeGenerator : IIncrementalGenerator
 
             foreach (var method in methods.Value)
             {
-                methodList ??= new List<MethodInfo>();
-                methodList.Add(method);
+                (methodList ??= []).Add(method);
                 if (method.IsPropertyAlias)
                 {
-                    propertyAliases ??= new List<MethodInfo>();
-                    propertyAliases.Add(method);
+                    (propertyAliases ??= []).Add(method);
                 }
                 else
                 {
-                    methodAliases ??= new List<MethodInfo>();
-                    methodAliases.Add(method);
+                    (methodAliases ??= []).Add(method);
                 }
             }
 

--- a/src/Cake.Generator.Core/InternalsVisibleTo.Benchmarks.cs
+++ b/src/Cake.Generator.Core/InternalsVisibleTo.Benchmarks.cs
@@ -1,2 +1,0 @@
-using System.Runtime.CompilerServices;
-[assembly: InternalsVisibleTo("Cake.Generator.Core.BenchmarkSuite")]

--- a/src/Cake.Sdk/Cake.SDK.TrimmerRootDescriptor.xml
+++ b/src/Cake.Sdk/Cake.SDK.TrimmerRootDescriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="Spectre.Console" preserve="all" />
+  <assembly fullname="Spectre.Console.Cli" preserve="all" />
+  <assembly fullname="Cake.Sdk" preserve="all" />
+  <assembly fullname="Cake.Cli" preserve="all" />
+  <assembly fullname="Cake.Common" preserve="all" />
+  <assembly fullname="Cake.Core" preserve="all" />
+  <assembly fullname="Cake.DotNetTool.Module" preserve="all" />
+  <assembly fullname="Cake.NuGet" preserve="all" />
+</linker>

--- a/src/Cake.Sdk/Cake.Sdk.csproj
+++ b/src/Cake.Sdk/Cake.Sdk.csproj
@@ -34,6 +34,7 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   
   <PropertyGroup>
+    <AssemblyName>Cake.Sdk</AssemblyName>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -53,6 +54,9 @@
     <Compile Include="__IncludeAdditionalFiles__" Exclude="__ExcludeAdditionalFiles__" />
   </ItemGroup>
 
+  <ItemGroup>
+    <TrimmerRootDescriptor Include="__MSBuildThisFileDirectory__/../Cake.SDK.TrimmerRootDescriptor.xml" />
+  </ItemGroup>
 </Project>]]></SdkPropsContent>
       <SdkTargetsContent><![CDATA[<Project>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
@@ -62,7 +66,7 @@
           <!-- Replace placeholders with actual values and MSBuild properties -->
       <PropertyGroup>
         <DollarSign>$</DollarSign>
-        <SdkPropsContentWithVersion>$([System.String]::Copy('$(SdkPropsContent)').Replace('__VERSION__', '$(Version)').Replace('__IncludeAdditionalFiles__', '$(DollarSign)(IncludeAdditionalFiles)').Replace('__ExcludeAdditionalFiles__', '$(DollarSign)(ExcludeAdditionalFiles)'))</SdkPropsContentWithVersion>
+        <SdkPropsContentWithVersion>$([System.String]::Copy('$(SdkPropsContent)').Replace('__VERSION__', '$(Version)').Replace('__IncludeAdditionalFiles__', '$(DollarSign)(IncludeAdditionalFiles)').Replace('__ExcludeAdditionalFiles__', '$(DollarSign)(ExcludeAdditionalFiles)').Replace('__MSBuildThisFileDirectory__', '$(DollarSign)(MSBuildThisFileDirectory)'))</SdkPropsContentWithVersion>
       </PropertyGroup>
     
     <!-- Ensure directories exist -->
@@ -88,4 +92,8 @@
     <None Include="Generated/build/Cake.Sdk.targets" Pack="true" PackagePath="build/Cake.Sdk.targets" />
   </ItemGroup>
 
+  <!-- Include Cake.SDK.TrimmerRootDescriptor.xml -->
+  <ItemGroup>
+    <None Include="Cake.SDK.TrimmerRootDescriptor.xml" Pack="true" PackagePath="Cake.SDK.TrimmerRootDescriptor.xml" />
+  </ItemGroup>
 </Project> 


### PR DESCRIPTION
- **Add trimmer root descriptor for Cake.Sdk to preserve required assemblies during AOT/trimming**
- **Update project file to include trimmer descriptor in package for proper AOT deployment**
- Convert classes to use primary constructors (MethodInfo, ModuleInfo, StringBuilderScope)
- Replace array/list initializations with collection expressions
- Use ImmutableArray instead of string[] for better performance
- Move InternalsVisibleTo attribute from separate file to project file
- Fix whitespace formatting in generated CakeAppSettings class