### PR TITLE
Update NuGet authentication to use OIDC with temporary API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,18 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{secrets.NUGET_USER}}
+
       - name: Build Cake Generator & SDK
         uses: cake-build/cake-action@master
         env:
           AZURE_DEVOPS_NUGET_API_KEY: ${{ secrets.AZURE_DEVOPS_NUGET_API_KEY }}
           AZURE_DEVOPS_NUGET_API_URL: ${{ secrets.AZURE_DEVOPS_NUGET_API_URL }}
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{steps.login.outputs.NUGET_API_KEY}}
           NUGET_API_URL: ${{ secrets.NUGET_API_URL }}
           SIGN_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           SIGN_CLIENT_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
- Add NuGet login step using OIDC authentication
- Replace static NUGET_API_KEY secret with dynamically generated temporary key
- Improve security by using short-lived API keys instead of long-term secrets