### PR TITLE
docs: update documentation and fix package table links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Package                                       | Latest Release                                                                                                |
 |-----------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| Cake.Generator                                | [![NuGet](https://img.shields.io/nuget/v/Cake.Generator.svg)](https://www.nuget.org/packages/Cake.Generator) |
+| [Cake.Generator](README.md)                   | [![NuGet](https://img.shields.io/nuget/v/Cake.Generator.svg)](https://www.nuget.org/packages/Cake.Generator) |
 | [Cake.Sdk](src/Cake.Sdk/README.md)            | [![NuGet](https://img.shields.io/nuget/v/Cake.Sdk.svg)](https://www.nuget.org/packages/Cake.Sdk)             |
 | [Cake.Template](src/Cake.Template/README.md)  | [![NuGet](https://img.shields.io/nuget/v/Cake.Generator.svg)](https://www.nuget.org/packages/Cake.Template)  |
 

--- a/src/Cake.Sdk/README.md
+++ b/src/Cake.Sdk/README.md
@@ -175,6 +175,31 @@ Task("MyTask")
     });
 ```
 
+### Multiple Main Entry Points
+
+You can define multiple entry points using `Main_*` prefixed methods that are automatically discovered and executed:
+
+```csharp
+// Program.Main.cs
+public static partial class Program
+{
+    private static void Main_One()
+    {
+        Task(nameof(Main_One))
+            .IsDependeeOf("Clean")
+            .Does(() => Information("Hello from Main_One"));
+    }
+
+    private static void Main_Two()
+    {
+        Task(nameof(Main_Two))
+            .IsDependeeOf("Clean")
+            .Does(() => Information("Hello from Main_Two"));
+    }
+}
+```
+
+
 ## What's Included
 
 The Cake.Sdk automatically configures the following properties:
@@ -182,7 +207,7 @@ The Cake.Sdk automatically configures the following properties:
 - `OutputType`: Exe
 - `Nullable`: enable
 - `ImplicitUsings`: enable
-- `Optimize`: true
+- `Optimize`: false
 - `DebugType`: portable
 - `DebugSymbols`: true
 - `LangVersion`: latest


### PR DESCRIPTION
- Add link to main README.md for Cake.Generator package in package table
- Add Multiple Main Entry Points section to Cake.Sdk README with examples
- Fix Optimize property value from true to false in Cake.Sdk documentation
- Include practical examples of Main_One and Main_Two methods with task dependencies