### PR TITLE
chore: update test and benchmark dependencies to latest versions

### DIFF
--- a/src/Cake.Generator.Core.BenchmarkSuite/Directory.Packages.props
+++ b/src/Cake.Generator.Core.BenchmarkSuite/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
     <!-- Test dependencies -->
-    <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36525.3" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,9 +19,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <!-- Test dependencies -->
-    <PackageVersion Include="TUnit" Version="0.57.63" />
+    <PackageVersion Include="TUnit" Version="0.63.3" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.TUnit" Version="30.11.0" />
+    <PackageVersion Include="Verify.TUnit" Version="30.19.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.TUnit" Version="30.19.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates various test and benchmark dependencies to their latest versions to ensure we're using the most recent features, bug fixes, and security updates.

### Changes
- **BenchmarkDotNet**: 0.15.2 → 0.15.4
- **Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers**: 18.0.36421.1 → 18.0.36525.3
- **TUnit**: 0.57.63 → 0.63.3
- **Verify.TUnit**: 30.11.0 → 30.19.2
- **Microsoft.NET.Test.Sdk**: 17.14.1 → 18.0.0