### PR TITLE
Update .NET 10 RC dependencies and test framework configuration

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.1.25451.107"
+    "rollForward": "latestFeature",
+    "version": "10.0.100-rc.2.25502.107"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "rollForward": "latestFeature",
     "version": "10.0.100-rc.2.25502.107"
+  },
+  "test": {
+      "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/Cake.Generator.TestApp/Program/Program.Test.cs
+++ b/src/Cake.Generator.TestApp/Program/Program.Test.cs
@@ -3,12 +3,13 @@ public static partial class Program
     private static void Test(ICakeContext ctx, BuildData data)
     {
         DotNetTest(
-            data.SolutionPath.FullPath,
+            null!,
             new DotNetTestSettings
             {
                 MSBuildSettings = data.MSBuildSettings,
                 NoBuild = true,
                 NoRestore = true,
+                ArgumentCustomization = args => args.AppendSwitch("--solution",  data.SolutionPath.FullPath.Quote())
             });
     }
 }

--- a/src/Cake.Generator/Cake.Generator.csproj
+++ b/src/Cake.Generator/Cake.Generator.csproj
@@ -22,10 +22,10 @@
     <PackageReference Include="Cake.NuGet" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.0-rc.1.25451.107" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.0-rc.2.25502.107" Condition="'$(TargetFramework)' == 'net10.0'" />
 
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.9" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0-rc.1.25451.107" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0-rc.2.25502.107" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <!-- Reference the core source generator project -->

--- a/src/Cake.Sdk/Cake.Sdk.csproj
+++ b/src/Cake.Sdk/Cake.Sdk.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Cake.NuGet" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.0-rc.1.25451.107" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.0-rc.2.25502.107" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <!-- Generate SDK files with actual version during build -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,9 +19,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <!-- Test dependencies -->
-    <PackageVersion Include="TUnit" Version="0.63.3" />
+    <PackageVersion Include="TUnit" Version="0.73.19" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.TUnit" Version="30.19.2" />
+    <PackageVersion Include="Verify.TUnit" Version="31.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Cake.Twitter" Version="5.0.0" />
     <PackageVersion Include="Cake.BuildSystems.Module" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <!-- Test dependencies -->


### PR DESCRIPTION
This PR updates the project to use the latest .NET 10 RC2 dependencies and configures the new Microsoft Testing Platform for improved test execution.

## Changes Made

### .NET 10 RC2 Update
- **global.json**: Updated SDK version from `10.0.100-rc.1.25451.107` to `10.0.100-rc.2.25502.107`
- **Package Dependencies**: Updated Microsoft.Extensions.DependencyInjection and System.Collections.Immutable to RC2 versions
- **SDK Configuration**: Added `rollForward: "latestFeature"` for better SDK compatibility

### Test Framework Updates
- **global.json**: Added Microsoft Testing Platform configuration (`"runner": "Microsoft.Testing.Platform"`)
- **Test Dependencies**: Updated TUnit from `0.63.3` to `0.73.19` and Verify.TUnit from `30.19.2` to `31.0.2`
- **Package Dependencies**: Updated Microsoft.Extensions.DependencyInjection to `9.0.10` and System.Collections.Immutable to `9.0.10`

### Test Configuration Fix
- **Program.Test.cs**: Fixed DotNetTest call to use `--solution` argument instead of direct solution path parameter
- This ensures compatibility with the new testing platform requirements

