### PR TITLE
fix: resolve BuildSystem class/property ambiguity

### DIFF
--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeAliasGlobalUsings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeAliasGlobalUsings.g.verified.cs
@@ -3,7 +3,6 @@
 
 global using global::Cake.Cli;
 global using global::Cake.Common;
-global using global::Cake.Common.Build;
 global using global::Cake.Common.Build.AppVeyor;
 global using global::Cake.Common.Build.AppVeyor.Data;
 global using global::Cake.Common.Build.AzurePipelines;

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeAliasGlobalUsings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeAliasGlobalUsings.g.verified.cs
@@ -3,7 +3,6 @@
 
 global using global::Cake.Cli;
 global using global::Cake.Common;
-global using global::Cake.Common.Build;
 global using global::Cake.Common.Build.AppVeyor;
 global using global::Cake.Common.Build.AppVeyor.Data;
 global using global::Cake.Common.Build.AzurePipelines;

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeAliasGlobalUsings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeAliasGlobalUsings.g.verified.cs
@@ -3,7 +3,6 @@
 
 global using global::Cake.Cli;
 global using global::Cake.Common;
-global using global::Cake.Common.Build;
 global using global::Cake.Common.Build.AppVeyor;
 global using global::Cake.Common.Build.AppVeyor.Data;
 global using global::Cake.Common.Build.AzurePipelines;

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.GlobalUsings.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.GlobalUsings.cs
@@ -8,6 +8,11 @@ public partial class CakeGenerator
 {
     private static string GenerateGlobalUsings(List<MethodInfo> methods)
     {
+        var excludedNamespaces = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Cake.Common.Build" // Exclude Cake.Common.Build to avoid conflicts with BuildSystem property and class.
+        };
+
         var foundNamespaces = new HashSet<string>(StringComparer.Ordinal)
         {
             "System",
@@ -55,6 +60,7 @@ public partial class CakeGenerator
         var globalUsings = string.Join(
                                 "\n",
                                 foundNamespaces
+                                    .Except(excludedNamespaces)
                                     .OrderBy(x => x)
                                     .Select(ns => $"global using global::{ns};"));
         sb.StringBuilder.AppendLine(globalUsings);

--- a/src/Cake.Generator.TestApp/Program.cs
+++ b/src/Cake.Generator.TestApp/Program.cs
@@ -30,7 +30,7 @@ Task("Pack")
 Task("UploadArtifact")
     .IsDependentOn("Pack")
     .IsDependentOn("Sign-Binaries")
-    .WithCriteria(GitHubActions.IsRunningOnGitHubActions, nameof(GitHubActions.IsRunningOnGitHubActions))
+    .WithCriteria(BuildSystem.IsRunningOnGitHubActions, nameof(BuildSystem.IsRunningOnGitHubActions))
     .Does<BuildData>(UploadArtifact);
 
 Task("IntegrationTest-Setup")
@@ -59,7 +59,7 @@ Task("IntegrationTest-PrepareProjects")
 
 Task("IntegrationTest-UploadTestCases-Artifacts")
     .IsDependentOn("IntegrationTest-PrepareProjects")
-    .WithCriteria(GitHubActions.IsRunningOnGitHubActions, nameof(GitHubActions.IsRunningOnGitHubActions))
+    .WithCriteria(BuildSystem.IsRunningOnGitHubActions, nameof(BuildSystem.IsRunningOnGitHubActions))
     .Does<BuildData>(IntegrationTestUploadTestCasesArtifacts);
 
 Task("IntegrationTest-Execute")


### PR DESCRIPTION
- Exclude Cake.Common.Build namespace from global usings to avoid conflicts
- Update integration test GitHubActions.IsRunningOnGitHubActions references to BuildSystem.IsRunningOnGitHubActions
- Update verified test files to reflect namespace exclusion