### PR TITLE
Upgrade to .NET 10 stable

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "10.0.100-rc.2.25502.107"
+    "version": "10.0.100"
   },
   "test": {
       "runner": "Microsoft.Testing.Platform"

--- a/src/Cake.Generator/Cake.Generator.csproj
+++ b/src/Cake.Generator/Cake.Generator.csproj
@@ -21,11 +21,11 @@
     <PackageReference Include="Cake.DotNetTool.Module" />
     <PackageReference Include="Cake.NuGet" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.0-rc.2.25502.107" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Condition="'$(TargetFramework)' == 'net10.0'" />
 
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0-rc.2.25502.107" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.11" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
   <!-- Reference the core source generator project -->

--- a/src/Cake.Sdk/Cake.Sdk.csproj
+++ b/src/Cake.Sdk/Cake.Sdk.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="Cake.DotNetTool.Module" />
     <PackageReference Include="Cake.NuGet" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.0-rc.2.25502.107" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <!-- Generate SDK files with actual version during build -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageVersion Include="Cake.Core" Version="5.1.0" />
     <PackageVersion Include="Cake.Common" Version="5.1.0" />
@@ -15,7 +14,7 @@
     <PackageVersion Include="Cake.Twitter" Version="5.0.0" />
     <PackageVersion Include="Cake.BuildSystems.Module" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <!-- Test dependencies -->


### PR DESCRIPTION
- Update global.json SDK version from RC to stable (10.0.100)
- Update Microsoft.Extensions.DependencyInjection to 10.0.0 stable
- Remove RC version overrides for net10.0 target framework
- Update System.Collections.Immutable to 9.0.11 for net8.0 and net9.0
- Remove Microsoft.SourceLink.GitHub package reference
