### PR TITLE
GH45: Fix missing exception handling in GeneratorScriptHost

### DIFF
--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeScriptHost.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeScriptHost.g.verified.cs
@@ -46,17 +46,43 @@ public static partial class Program
         public override async Task<CakeReport> RunTargetAsync(string target)
         {
             Settings.SetTarget(target);
-            var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-            reporter.Write(report);
+            var report = await internalRunTargetAsync();
             return report;
         }
 
         public override async Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
         {
             Settings.SetTargets(targets);
-            var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-            reporter.Write(report);
+            var report = await internalRunTargetAsync();
             return report;
+        }
+
+        private async Task<CakeReport> internalRunTargetAsync()
+        {
+            try
+            {
+                var report = await Engine
+                                    .RunTargetAsync(Context, strategy, Settings)
+                                    .ConfigureAwait(false);
+
+                if (report != null && !report.IsEmpty)
+                {
+                    reporter.Write(report);
+                }
+
+                ArgumentNullException.ThrowIfNull(report);
+
+                return report;
+            }
+            catch (CakeReportException cre)
+            {
+                if (cre.Report != null && !cre.Report.IsEmpty)
+                {
+                    reporter.Write(cre.Report);
+                }
+
+                throw;
+            }
         }
     }
 

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeScriptHost.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeScriptHost.g.verified.cs
@@ -47,17 +47,43 @@ public static partial class Program
         public override async Task<CakeReport> RunTargetAsync(string target)
         {
             Settings.SetTarget(target);
-            var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-            reporter.Write(report);
+            var report = await internalRunTargetAsync();
             return report;
         }
 
         public override async Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
         {
             Settings.SetTargets(targets);
-            var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-            reporter.Write(report);
+            var report = await internalRunTargetAsync();
             return report;
+        }
+
+        private async Task<CakeReport> internalRunTargetAsync()
+        {
+            try
+            {
+                var report = await Engine
+                                    .RunTargetAsync(Context, strategy, Settings)
+                                    .ConfigureAwait(false);
+
+                if (report != null && !report.IsEmpty)
+                {
+                    reporter.Write(report);
+                }
+
+                ArgumentNullException.ThrowIfNull(report);
+
+                return report;
+            }
+            catch (CakeReportException cre)
+            {
+                if (cre.Report != null && !cre.Report.IsEmpty)
+                {
+                    reporter.Write(cre.Report);
+                }
+
+                throw;
+            }
         }
     }
 

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeScriptHost.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeScriptHost.g.verified.cs
@@ -46,17 +46,43 @@ public static partial class Program
         public override async Task<CakeReport> RunTargetAsync(string target)
         {
             Settings.SetTarget(target);
-            var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-            reporter.Write(report);
+            var report = await internalRunTargetAsync();
             return report;
         }
 
         public override async Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
         {
             Settings.SetTargets(targets);
-            var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-            reporter.Write(report);
+            var report = await internalRunTargetAsync();
             return report;
+        }
+
+        private async Task<CakeReport> internalRunTargetAsync()
+        {
+            try
+            {
+                var report = await Engine
+                                    .RunTargetAsync(Context, strategy, Settings)
+                                    .ConfigureAwait(false);
+
+                if (report != null && !report.IsEmpty)
+                {
+                    reporter.Write(report);
+                }
+
+                ArgumentNullException.ThrowIfNull(report);
+
+                return report;
+            }
+            catch (CakeReportException cre)
+            {
+                if (cre.Report != null && !cre.Report.IsEmpty)
+                {
+                    reporter.Write(cre.Report);
+                }
+
+                throw;
+            }
         }
     }
 

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.ScriptHost.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.ScriptHost.cs
@@ -76,17 +76,43 @@ public partial class CakeGenerator
                     public override async Task<CakeReport> RunTargetAsync(string target)
                     {
                         Settings.SetTarget(target);
-                        var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-                        reporter.Write(report);
+                        var report = await internalRunTargetAsync();
                         return report;
                     }
 
                     public override async Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
                     {
                         Settings.SetTargets(targets);
-                        var report = await Engine.RunTargetAsync(Context, strategy, Settings);
-                        reporter.Write(report);
+                        var report = await internalRunTargetAsync();
                         return report;
+                    }
+
+                    private async Task<CakeReport> internalRunTargetAsync()
+                    {
+                        try
+                        {
+                            var report = await Engine
+                                                .RunTargetAsync(Context, strategy, Settings)
+                                                .ConfigureAwait(false);
+
+                            if (report != null && !report.IsEmpty)
+                            {
+                                reporter.Write(report);
+                            }
+
+                            ArgumentNullException.ThrowIfNull(report);
+
+                            return report;
+                        }
+                        catch (CakeReportException cre)
+                        {
+                            if (cre.Report != null && !cre.Report.IsEmpty)
+                            {
+                                reporter.Write(cre.Report);
+                            }
+
+                            throw;
+                        }
                     }
                 }
             """);


### PR DESCRIPTION
Add top-level exception handling to GeneratorScriptHost to match BuildScriptHost behavior. This ensures CakeReportException reports are displayed before rethrowing, providing consistent error output between `dotnet cake` and `dotnet cake.cs` commands.

* Fixes #45