### PR TITLE
GH57: Update BenchmarkDotNet to 0.15.8

### DIFF
--- a/src/Cake.Generator.Core.BenchmarkSuite/Directory.Packages.props
+++ b/src/Cake.Generator.Core.BenchmarkSuite/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <!-- Test dependencies -->
-    <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36525.3" />
+    <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.3.36812.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* fixes #57