### PR TITLE
GH92: Use Cake NuGet Feed for cake-build/cake packages

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+workflow: GitFlow/v1
+next-version: 6.0.0
+branches:
+  main:
+    label: beta

--- a/src/Cake.Generator.TestApp/IntegrationTest/nuget.config.template
+++ b/src/Cake.Generator.TestApp/IntegrationTest/nuget.config.template
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="local" value="LOCAL_SOURCE_PATH" />
     <add key="cake" value="https://pkgs.dev.azure.com/cake-build/Cake/_packaging/cake/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="local">
+      <package pattern="Cake.Sdk" />
+      <package pattern="Cake.Generator" />
+      <package pattern="Cake.Template" />
+    </packageSource>
     <packageSource key="cake">
       <package pattern="Cake.Cli" />
       <package pattern="Cake.Common" />

--- a/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestSetup.cs
+++ b/src/Cake.Generator.TestApp/Program/IntegrationTest/Program.IntegrationTestSetup.cs
@@ -5,5 +5,29 @@ public static partial class Program
         data.DotNet("new nugetconfig");
 
         data.DotNet($"nuget add source --name local \"{data.OutputDirectory.FullPath.Replace('/', System.IO.Path.DirectorySeparatorChar)}\"");
+
+        data.DotNet("nuget add source --name cake \"https://pkgs.dev.azure.com/cake-build/Cake/_packaging/cake/nuget/v3/index.json\"");
+
+        var configPath = data.IntegrationTest.NuGetConfig.FullPath;
+        var doc = System.Xml.Linq.XDocument.Load(configPath);
+        var config = doc.Root!;
+        var mapping = new System.Xml.Linq.XElement("packageSourceMapping",
+            new System.Xml.Linq.XElement("packageSource",
+                new System.Xml.Linq.XAttribute("key", "local"),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.Sdk")),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.Generator")),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.Template"))),
+            new System.Xml.Linq.XElement("packageSource",
+                new System.Xml.Linq.XAttribute("key", "cake"),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.Cli")),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.Common")),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.Core")),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.DotNetTool.Module")),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "Cake.NuGet"))),
+            new System.Xml.Linq.XElement("packageSource",
+                new System.Xml.Linq.XAttribute("key", "nuget"),
+                new System.Xml.Linq.XElement("package", new System.Xml.Linq.XAttribute("pattern", "*"))));
+        config.Add(mapping);
+        doc.Save(configPath);
     }
 }

--- a/src/Cake.Generator.TestApp/Program/Program.Setup.cs
+++ b/src/Cake.Generator.TestApp/Program/Program.Setup.cs
@@ -14,18 +14,18 @@ public static partial class Program
         }
 
         var buildDate = DateTime.UtcNow;
-        var baseVersion = typeof(ICakeContext).Assembly.GetName().Version?.ToString(2) ?? "1.0";
+        var baseVersion = typeof(ICakeContext).Assembly.GetName().Version?.ToString(3) ?? "1.0.0";
 
-        var branchName = GitVersion(new GitVersionSettings { }).BranchName;
+        var assertedVersions = GitVersion(new GitVersionSettings
+            {
+                OutputType = GitVersionOutput.Json
+            });
+        var branchName = assertedVersions.BranchName;
         var isMain = StringComparer.OrdinalIgnoreCase.Equals("main", branchName);
         var isDevelopment = StringComparer.OrdinalIgnoreCase.Equals("develop", branchName);
         var isPullRequest = GitHubActions.IsRunningOnGitHubActions && GitHubActions.Environment.PullRequest.IsPullRequest;
         var isFork = GitHubActions.IsRunningOnGitHubActions && !StringComparer.OrdinalIgnoreCase.Equals("cake-build", GitHubActions.Environment.Workflow.RepositoryOwner);
         var isTagged = GitHubActions.IsRunningOnGitHubActions && GitHubActions.Environment.Workflow.RefType == GitHubActionsRefType.Tag;
-
-        var runNumber = GitHubActions.IsRunningOnGitHubActions
-                    ? GitHubActions.Environment.Workflow.RunNumber
-                    : (short)((buildDate - buildDate.Date).TotalSeconds / 3);
 
         var suffix = GitHubActions.IsRunningOnGitHubActions
                     ? (isMain ? string.Empty : "alpha")
@@ -36,20 +36,10 @@ public static partial class Program
                             ? semVersion.VersionString
                             : throw new CakeException($"Failed to parse tagged ref name: {GitHubActions.Environment.Workflow.RefName}"))
                         : FormattableString
-                                    .Invariant($"{baseVersion}.{buildDate:yy}{buildDate.DayOfYear:000}.{runNumber}-{suffix}")
+                                    .Invariant($"{baseVersion}-{suffix}{assertedVersions.PreReleaseNumber:D4}")
                                     .TrimEnd('-');
 
         var sdkVersion = ReadSdkVersionFromGlobalJson();
-
-        Information(
-            "Branch: {0} (Main: {1}, Development: {2}, Pull Request: {3}, Fork: {4}), Version: {5} (SDK: {6})",
-            branchName,
-            isMain,
-            isDevelopment,
-            isPullRequest,
-            isFork,
-            version,
-            sdkVersion);
 
         var msBuildSettings = new DotNetMSBuildSettings()
                 .SetConfiguration("IntegrationTest")
@@ -62,40 +52,65 @@ public static partial class Program
         {
             msBuildSettings.WithProperty("TemplateVersion", version);
         }
-
-        var buildData = new BuildData(
-            Version: version,
-            BranchName: branchName,
-            IsPullRequest: isPullRequest,
-            IsMainBranch: isMain,
-            IsDevelopmentBranch: isDevelopment,
-            IsFork: isFork,
-            IsTagged: isTagged,
-            IsRunningOnGitHubActions: GitHubActions.IsRunningOnGitHubActions,
-            IsRunningOnWindows: IsRunningOnWindows(),
-            ArtifactsDirectory: MakeAbsolute(Directory("artifacts")),
-            SolutionPath: GetFiles("./src/Cake.Generator.slnx").FirstOrDefault() ?? throw new CakeException("Failed to find solution"),
-            MSBuildSettings: msBuildSettings,
-            NuGetPublishSettings: new NuGetPublishSettings(
-                                    isMain,
-                                    isTagged,
-                                    Context.Environment),
-            CodeSigningCredentials: CodeSigningCredentials.GetCodeSigningCredentials(context));
-
-        if (buildData.ShouldSignPackages)
+        bool? shouldSignPackages = null;
+        try
         {
-            Information("Code signing is enabled for this build.");
-            if (!buildData.CodeSigningCredentials.HasCredentials)
+            var buildData = new BuildData(
+                Version: version,
+                BranchName: branchName,
+                IsPullRequest: isPullRequest,
+                IsMainBranch: isMain,
+                IsDevelopmentBranch: isDevelopment,
+                IsFork: isFork,
+                IsTagged: isTagged,
+                IsRunningOnGitHubActions: GitHubActions.IsRunningOnGitHubActions,
+                IsRunningOnWindows: IsRunningOnWindows(),
+                ArtifactsDirectory: MakeAbsolute(Directory("artifacts")),
+                SolutionPath: GetFiles("./src/Cake.Generator.slnx").FirstOrDefault() ?? throw new CakeException("Failed to find solution"),
+                MSBuildSettings: msBuildSettings,
+                NuGetPublishSettings: new NuGetPublishSettings(
+                                        isMain,
+                                        isTagged,
+                                        Context.Environment),
+                CodeSigningCredentials: CodeSigningCredentials.GetCodeSigningCredentials(context));
+
+            shouldSignPackages = buildData.ShouldSignPackages;
+
+            if (buildData.ShouldSignPackages)
             {
-                throw new CakeException("Code signing credentials are not set. Please set the environment variables for code signing.");
+                Information("Code signing is enabled for this build.");
+                if (!buildData.CodeSigningCredentials.HasCredentials)
+                {
+                    throw new CakeException("Code signing credentials are not set. Please set the environment variables for code signing.");
+                }
             }
-        }
-        else
-        {
-            Information("Code signing is disabled for this build.");
-        }
 
-        return buildData;
+            return buildData;
+        }
+        finally
+        {
+            /// <summary>Returns Spectre.Console markup for a boolean (green ✓ or red ✗).</summary>
+            static string ToCheckmark(bool? value) => value.HasValue ? (value.Value ? "[green]✓[/]" : "[red]✗[/]") : "[yellow]?[/]";
+
+            AnsiConsole.Write(
+                new Table()
+                    .RoundedBorder()
+                    .HideHeaders()
+                    .ShowRowSeparators()
+                    .AddColumn("Property")
+                    .AddColumn("Value")
+                    .AddRow("Build Date", buildDate.ToString("yyyy-MM-dd HH:mm:ss UTC"))
+                    .AddRow("Build System", BuildSystem.Provider.ToString("F"))
+                    .AddRow("Branch", branchName)
+                    .AddRow("Main", ToCheckmark(isMain))
+                    .AddRow("Development", ToCheckmark(isDevelopment))
+                    .AddRow("Pull Request", ToCheckmark(isPullRequest))
+                    .AddRow("Fork", ToCheckmark(isFork))
+                    .AddRow("Tagged", ToCheckmark(isTagged))
+                    .AddRow("Version", version)
+                    .AddRow("SDK", sdkVersion)
+                    .AddRow("Should Sign Packages", ToCheckmark(shouldSignPackages)));
+        }
     }
 
     private static string ReadSdkVersionFromGlobalJson()

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,11 +6,11 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
-    <PackageVersion Include="Cake.Core" Version="6.1.0" />
-    <PackageVersion Include="Cake.Common" Version="6.1.0" />
-    <PackageVersion Include="Cake.Cli" Version="6.1.0" />
-    <PackageVersion Include="Cake.DotNetTool.Module" Version="6.1.0" />
-    <PackageVersion Include="Cake.NuGet" Version="6.1.0" />
+    <PackageVersion Include="Cake.Core" Version="6.2.0-alpha0008" />
+    <PackageVersion Include="Cake.Common" Version="6.2.0-alpha0008" />
+    <PackageVersion Include="Cake.Cli" Version="6.2.0-alpha0008" />
+    <PackageVersion Include="Cake.DotNetTool.Module" Version="6.2.0-alpha0008" />
+    <PackageVersion Include="Cake.NuGet" Version="6.2.0-alpha0008" />
     <PackageVersion Include="Cake.Twitter" Version="6.0.0" />
     <PackageVersion Include="Cake.BuildSystems.Module" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />


### PR DESCRIPTION
- Add GitVersion.yml with GitFlow workflow and next-version 6.0.0
- Add Cake NuGet feed and package source mapping in nuget.config
- Add integration test nuget.config.template with local, cake, and nuget sources
- Configure integration tests to add Cake feed and package source mapping
- Use GitVersion for version and branch in Program.Setup (3-part base version, PreReleaseNumber)
- Bump Cake.* packages to 6.2.0-alpha0008 in Directory.Packages.props
- fixes #92