### PR TITLE
GH91: Add config to skip CakeReportPrinter

### DIFF
--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeCakeAppSettings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeCakeAppSettings.g.verified.cs
@@ -42,4 +42,8 @@ internal sealed class CakeAppSettings : Spectre.Console.Cli.CommandSettings
     [CommandOption("--info")]
     [Description("Displays additional information about Cake.")]
     public bool Info { get; set; }
+
+    [CommandOption("--no-report")]
+    [Description("Prevent the display of the summary report at the end of Cake Execution.")]
+    public bool NoReport { get; set; }
 }

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeHelper.AddCakeCli.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeHelper.AddCakeCli.g.verified.cs
@@ -46,7 +46,7 @@ public static partial class Program
             services.AddSingleton(interceptor.CakeAppSettings);
             services.AddSingleton<Spectre.Console.Cli.CommandSettings>(provider => provider.GetRequiredService<CakeAppSettings>());
             
-            var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.Targets);
+            var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.NoReport, interceptor.CakeAppSettings.Targets);
             services.AddSingleton(arguments);
             services.AddSingleton<ICakeArguments>(arguments);
 

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeScriptHost.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators#CakeScriptHost.g.verified.cs
@@ -39,7 +39,7 @@ public static partial class Program
         }
     }
 
-    private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeReportPrinter reporter)
+    private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeConfiguration configuration, ICakeReportPrinter reporter)
         : ScriptHost(engine, context)
     {
 
@@ -59,13 +59,15 @@ public static partial class Program
 
         private async Task<CakeReport> internalRunTargetAsync()
         {
+            bool noReportEnabled = false;
             try
             {
+                noReportEnabled = bool.TrueString.Equals(configuration.GetValue("Settings_NoReport") ?? bool.FalseString, StringComparison.OrdinalIgnoreCase);
                 var report = await Engine
                                     .RunTargetAsync(Context, strategy, Settings)
                                     .ConfigureAwait(false);
 
-                if (report != null && !report.IsEmpty)
+                if (report != null && !report.IsEmpty && !noReportEnabled)
                 {
                     reporter.Write(report);
                 }
@@ -76,7 +78,7 @@ public static partial class Program
             }
             catch (CakeReportException cre)
             {
-                if (cre.Report != null && !cre.Report.IsEmpty)
+                if (cre.Report != null && !cre.Report.IsEmpty && !noReportEnabled)
                 {
                     reporter.Write(cre.Report);
                 }

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeCakeAppSettings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeCakeAppSettings.g.verified.cs
@@ -42,4 +42,8 @@ internal sealed class CakeAppSettings : Spectre.Console.Cli.CommandSettings
     [CommandOption("--info")]
     [Description("Displays additional information about Cake.")]
     public bool Info { get; set; }
+
+    [CommandOption("--no-report")]
+    [Description("Prevent the display of the summary report at the end of Cake Execution.")]
+    public bool NoReport { get; set; }
 }

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeHelper.AddCakeCli.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeHelper.AddCakeCli.g.verified.cs
@@ -46,7 +46,7 @@ public static partial class Program
             services.AddSingleton(interceptor.CakeAppSettings);
             services.AddSingleton<Spectre.Console.Cli.CommandSettings>(provider => provider.GetRequiredService<CakeAppSettings>());
             
-            var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.Targets);
+            var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.NoReport, interceptor.CakeAppSettings.Targets);
             services.AddSingleton(arguments);
             services.AddSingleton<ICakeArguments>(arguments);
 

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeScriptHost.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithMainMethods_GeneratesMainMethodCalls#CakeScriptHost.g.verified.cs
@@ -40,7 +40,7 @@ public static partial class Program
         }
     }
 
-    private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeReportPrinter reporter)
+    private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeConfiguration configuration, ICakeReportPrinter reporter)
         : ScriptHost(engine, context)
     {
 
@@ -60,13 +60,15 @@ public static partial class Program
 
         private async Task<CakeReport> internalRunTargetAsync()
         {
+            bool noReportEnabled = false;
             try
             {
+                noReportEnabled = bool.TrueString.Equals(configuration.GetValue("Settings_NoReport") ?? bool.FalseString, StringComparison.OrdinalIgnoreCase);
                 var report = await Engine
                                     .RunTargetAsync(Context, strategy, Settings)
                                     .ConfigureAwait(false);
 
-                if (report != null && !report.IsEmpty)
+                if (report != null && !report.IsEmpty && !noReportEnabled)
                 {
                     reporter.Write(report);
                 }
@@ -77,7 +79,7 @@ public static partial class Program
             }
             catch (CakeReportException cre)
             {
-                if (cre.Report != null && !cre.Report.IsEmpty)
+                if (cre.Report != null && !cre.Report.IsEmpty && !noReportEnabled)
                 {
                     reporter.Write(cre.Report);
                 }

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeCakeAppSettings.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeCakeAppSettings.g.verified.cs
@@ -42,4 +42,8 @@ internal sealed class CakeAppSettings : Spectre.Console.Cli.CommandSettings
     [CommandOption("--info")]
     [Description("Displays additional information about Cake.")]
     public bool Info { get; set; }
+
+    [CommandOption("--no-report")]
+    [Description("Prevent the display of the summary report at the end of Cake Execution.")]
+    public bool NoReport { get; set; }
 }

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeHelper.AddCakeCli.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeHelper.AddCakeCli.g.verified.cs
@@ -46,7 +46,7 @@ public static partial class Program
             services.AddSingleton(interceptor.CakeAppSettings);
             services.AddSingleton<Spectre.Console.Cli.CommandSettings>(provider => provider.GetRequiredService<CakeAppSettings>());
             
-            var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.Targets);
+            var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.NoReport, interceptor.CakeAppSettings.Targets);
             services.AddSingleton(arguments);
             services.AddSingleton<ICakeArguments>(arguments);
 

--- a/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeScriptHost.g.verified.cs
+++ b/src/Cake.Generator.Core.Tests/Unit/CakeGeneratorTests.RunGenerators_WithModules#CakeScriptHost.g.verified.cs
@@ -39,7 +39,7 @@ public static partial class Program
         }
     }
 
-    private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeReportPrinter reporter)
+    private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeConfiguration configuration, ICakeReportPrinter reporter)
         : ScriptHost(engine, context)
     {
 
@@ -59,13 +59,15 @@ public static partial class Program
 
         private async Task<CakeReport> internalRunTargetAsync()
         {
+            bool noReportEnabled = false;
             try
             {
+                noReportEnabled = bool.TrueString.Equals(configuration.GetValue("Settings_NoReport") ?? bool.FalseString, StringComparison.OrdinalIgnoreCase);
                 var report = await Engine
                                     .RunTargetAsync(Context, strategy, Settings)
                                     .ConfigureAwait(false);
 
-                if (report != null && !report.IsEmpty)
+                if (report != null && !report.IsEmpty && !noReportEnabled)
                 {
                     reporter.Write(report);
                 }
@@ -76,7 +78,7 @@ public static partial class Program
             }
             catch (CakeReportException cre)
             {
-                if (cre.Report != null && !cre.Report.IsEmpty)
+                if (cre.Report != null && !cre.Report.IsEmpty && !noReportEnabled)
                 {
                     reporter.Write(cre.Report);
                 }

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.CakeAppSettings.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.CakeAppSettings.cs
@@ -52,6 +52,10 @@ public partial class CakeGenerator
             [CommandOption("--info")]
             [Description("Displays additional information about Cake.")]
             public bool Info { get; set; }
+
+            [CommandOption("--no-report")]
+            [Description("Prevent the display of the summary report at the end of Cake Execution.")]
+            public bool NoReport { get; set; }
         }
         """;
 }

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeCli.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.Helper.Services.AddCakeCli.cs
@@ -59,7 +59,7 @@ public partial class CakeGenerator
                         services.AddSingleton(interceptor.CakeAppSettings);
                         services.AddSingleton<Spectre.Console.Cli.CommandSettings>(provider => provider.GetRequiredService<CakeAppSettings>());
                         
-                        var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.Targets);
+                        var arguments = global::Cake.Cli.Infrastructure.IRemainingArgumentsExtensions.ToCakeArguments(ToUnQuotedRemainingArguments(interceptor.Context.Remaining), interceptor.CakeAppSettings.NoReport, interceptor.CakeAppSettings.Targets);
                         services.AddSingleton(arguments);
                         services.AddSingleton<ICakeArguments>(arguments);
 

--- a/src/Cake.Generator.Core/CakeGenerator.Generate.ScriptHost.cs
+++ b/src/Cake.Generator.Core/CakeGenerator.Generate.ScriptHost.cs
@@ -69,7 +69,7 @@ public partial class CakeGenerator
                     }
                 }
 
-                private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeReportPrinter reporter)
+                private class GeneratorScriptHost(ICakeEngine engine, ICakeContext context, IExecutionStrategy strategy, ICakeConfiguration configuration, ICakeReportPrinter reporter)
                     : ScriptHost(engine, context)
                 {
 
@@ -89,13 +89,15 @@ public partial class CakeGenerator
 
                     private async Task<CakeReport> internalRunTargetAsync()
                     {
+                        bool noReportEnabled = false;
                         try
                         {
+                            noReportEnabled = bool.TrueString.Equals(configuration.GetValue("Settings_NoReport") ?? bool.FalseString, StringComparison.OrdinalIgnoreCase);
                             var report = await Engine
                                                 .RunTargetAsync(Context, strategy, Settings)
                                                 .ConfigureAwait(false);
 
-                            if (report != null && !report.IsEmpty)
+                            if (report != null && !report.IsEmpty && !noReportEnabled)
                             {
                                 reporter.Write(report);
                             }
@@ -106,7 +108,7 @@ public partial class CakeGenerator
                         }
                         catch (CakeReportException cre)
                         {
-                            if (cre.Report != null && !cre.Report.IsEmpty)
+                            if (cre.Report != null && !cre.Report.IsEmpty && !noReportEnabled)
                             {
                                 reporter.Write(cre.Report);
                             }

--- a/src/Cake.Generator.TestApp/Cake.Generator.TestApp.csproj
+++ b/src/Cake.Generator.TestApp/Cake.Generator.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
- Add --no-report CLI option and NoReport to CakeAppSettings
- Pass NoReport into ToCakeArguments in AddCakeCli registration
- In GeneratorScriptHost, read Settings_NoReport and skip report output when enabled (normal and CakeReportException paths)
- Update Cake.Generator.TestApp to net10.0
- fixes #91