### PR TITLE
GH102: Update Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers to 18.6.37110.2

### DIFF
--- a/src/Cake.Generator.Core.BenchmarkSuite/Directory.Packages.props
+++ b/src/Cake.Generator.Core.BenchmarkSuite/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <!-- Test dependencies -->
-    <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.3.36812.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.6.37110.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* fixes #102